### PR TITLE
Release dangle ip associated to deleted pods when address conflict de…

### DIFF
--- a/pkg/controller/pod.go
+++ b/pkg/controller/pod.go
@@ -15,6 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -1225,10 +1226,58 @@ func generatePatchPayload(annotations map[string]string, op string) []byte {
 	return []byte(fmt.Sprintf(patchPayloadTemplate, op, raw))
 }
 
+func (c *Controller) recycleAddress(ipStrList []string, subnet string) error {
+	// get ip crd, check if crd exists. if crd not exists, release all pods related to the address, otherwise
+	podUsedIPs, err := c.config.KubeOvnClient.KubeovnV1().IPs().List(context.Background(), metav1.ListOptions{
+		LabelSelector: fields.OneTermEqualSelector(subnet, "").String(),
+	})
+	if err != nil {
+		klog.Errorf("failed to list ip crd, subnet:%v, err:%v", subnet, err)
+		return err
+	}
+
+	for _, ipStr := range ipStrList {
+		curPods := make(map[string]int)
+		for _, ipCrd := range podUsedIPs.Items {
+			if !(util.CheckProtocol(ipStr) == kubeovnv1.ProtocolIPv4 && ipCrd.Spec.V4IPAddress == ipStr) &&
+				!(util.CheckProtocol(ipStr) == kubeovnv1.ProtocolIPv6 && ipCrd.Spec.V6IPAddress == ipStr) {
+				continue
+			}
+
+			if _, err := c.podsLister.Pods(ipCrd.Spec.Namespace).Get(ipCrd.Spec.PodName); err != nil {
+				if k8serrors.IsNotFound(err) {
+					// delete ip crd that associated with pod which does not exist anymore
+					if err = c.config.KubeOvnClient.KubeovnV1().IPs().Delete(context.Background(), ipCrd.Name, metav1.DeleteOptions{}); err != nil {
+						klog.Errorf("failed to delete ip crd:%s, err:%v", ipCrd.Name, err)
+						return err
+					}
+					continue
+				} else {
+					klog.Errorf("failed to get pods:%s, err:%v", ipCrd.Spec.PodName, err)
+					return err
+				}
+			}
+
+			curPods[ipCrd.Spec.PodName] = 1
+		}
+
+		// release addresses that does not associate with existing pod
+		ipPodList := c.ipam.GetPodByIP(ipStr, subnet)
+		for _, podName := range ipPodList {
+			if _, ok := curPods[podName]; !ok {
+				c.ipam.ReleaseAddressByPod(podName)
+			}
+		}
+	}
+
+	return nil
+}
+
 func (c *Controller) acquireStaticAddress(key, nicName, ip, mac, subnet string, liveMigration bool) (string, string, string, error) {
 	var v4IP, v6IP string
 	var err error
-	for _, ipStr := range strings.Split(ip, ",") {
+	ipStrList := strings.Split(ip, ",")
+	for _, ipStr := range ipStrList {
 		if net.ParseIP(ipStr) == nil {
 			return "", "", "", fmt.Errorf("failed to parse IP %s", ipStr)
 		}
@@ -1236,6 +1285,11 @@ func (c *Controller) acquireStaticAddress(key, nicName, ip, mac, subnet string, 
 
 	if v4IP, v6IP, mac, err = c.ipam.GetStaticAddress(key, nicName, ip, mac, subnet, !liveMigration); err != nil {
 		klog.Errorf("failed to get static ip %v, mac %v, subnet %v, err %v", ip, mac, subnet, err)
+		if err == ipam.ErrConflict {
+			if errGc := c.recycleAddress(ipStrList, subnet); errGc != nil {
+				klog.Errorf("failed to recycleAddress, ip %v, subnet %v, err %v", ip, subnet, err)
+			}
+		}
 		return "", "", "", err
 	}
 	return v4IP, v6IP, mac, nil

--- a/pkg/controller/subnet.go
+++ b/pkg/controller/subnet.go
@@ -447,7 +447,7 @@ func (c *Controller) handleSubnetFinalizer(subnet *kubeovnv1.Subnet) (bool, erro
 	return false, nil
 }
 
-func (c Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, errStr string) {
+func (c *Controller) patchSubnetStatus(subnet *kubeovnv1.Subnet, reason string, errStr string) {
 	if errStr != "" {
 		subnet.Status.SetError(reason, errStr)
 		subnet.Status.NotValidated(reason, errStr)

--- a/pkg/ipam/ipam.go
+++ b/pkg/ipam/ipam.go
@@ -244,3 +244,14 @@ func (ipam *IPAM) IsIPAssignedToPod(ip, subnetName string) bool {
 		return subnet.isIPAssignedToPod(ip)
 	}
 }
+
+func (ipam *IPAM) GetPodByIP(ip string, subnetName string) (podList []string) {
+	ipam.mutex.RLock()
+	defer ipam.mutex.RUnlock()
+
+	if subnet, ok := ipam.Subnets[subnetName]; !ok {
+		return
+	} else {
+		return subnet.GetPodByIP(ip)
+	}
+}

--- a/pkg/ipam/subnet.go
+++ b/pkg/ipam/subnet.go
@@ -537,3 +537,20 @@ func (subnet *Subnet) isIPAssignedToPod(ip string) bool {
 	}
 	return false
 }
+
+func (subnet *Subnet) GetPodByIP(ip string) (podList []string) {
+	if pl, ok := subnet.V4IPToPod[IP(ip)]; ok {
+		if strings.TrimSpace(pl) != "" {
+			podList = strings.Split(pl, ",")
+		}
+		return
+	}
+	if pl6, ok := subnet.V6IPToPod[IP(ip)]; ok {
+		if strings.TrimSpace(pl6) != "" {
+			podList = strings.Split(pl6, ",")
+		}
+		return
+	}
+
+	return
+}


### PR DESCRIPTION
#### What type of this PR
Examples of user facing changes:
- Bug fixes

#### change
When ip crd was not deteled properly, address conflicts will occur when another pod acquire the same static ip. This PR release all the ip crd and cache in IPAM when address conflicts detected if the pod associated no longer exists .