### PR TITLE
fix lint

### DIFF
--- a/pkg/daemon/controller.go
+++ b/pkg/daemon/controller.go
@@ -1150,8 +1150,6 @@ func (c *Controller) markAndCleanOvsPort() {
 		}
 	}
 	lastNoPodOvsPort = noPodOvsPort
-
-	return
 }
 
 func (c *Controller) loopCheckSubnetQosPriority() {


### PR DESCRIPTION
redundant `return` statement